### PR TITLE
Formatting cleanup & CI dependency bumps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,15 +38,15 @@ jobs:
             arch: x86
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@latest
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(; path = pwd())); Pkg.instantiate();'
       - name: Build and deploy
@@ -72,7 +72,7 @@ jobs:
         run: julia --project=docs/ docs/make.jl
       - name: Make comment with preview link
         if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened'}}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibZip"
 uuid = "89089acc-ee81-44d2-83aa-3aa2951b1031"
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/ZipTools.jl
+++ b/src/ZipTools.jl
@@ -318,7 +318,7 @@ function _zip_error(f::Function)
     err = Ref{LibZipErrorT}(LibZipErrorT())
     libzip_error_init(err)
     try
-      return f(err)
+        return f(err)
     finally
         zip_error_fini(err)
     end


### PR DESCRIPTION
## Summary
- Bump patch version 1.2.0 → 1.2.1
- Fix indent in `_zip_error` function (2-space → 4-space)
- Bump julia-actions/setup-julia from 2 to 3
- Bump julia-actions/cache from 2 to 3
- Bump codecov/codecov-action from 5 to 6
- Bump actions/github-script from 8 to 9

Closes #21, closes #22, closes #23, closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)